### PR TITLE
Update console colors to softer equivalents

### DIFF
--- a/Kamsar.WebConsole/Resources/console.css
+++ b/Kamsar.WebConsole/Resources/console.css
@@ -16,7 +16,7 @@
 	}
 
 	.progress p#status {
-		color: gray;
+		color: #f2f2f2;
 		font-style: italic;
 		margin-top: 0.1em;
 		font-size: 0.9em;
@@ -26,8 +26,8 @@
 	font-size: 1.5em;
 	width: 100%;
 	height: 1.1em;
-	background-color: white;
-	border: 1px solid gray;
+	background-color: #f2f2f2;
+	border: 1px solid #f2f2f2;
 	text-align: center;
 }
 
@@ -42,7 +42,7 @@
 		float: left;
 		height: 1.1em;
 		width: 0%;
-		border-right: 1px solid gray;
+		border-right: 1px solid #f2f2f2;
 	}
 
 	.progressbar #percentage {
@@ -53,8 +53,8 @@
 	}
 
 #console {
-	background-color: black;
-	color: #0F0;
+	background-color: #0c0c0c;
+	color: #13a10e;
 	font-family: Consolas, 'Courier New', Courier, monospace;
 	height: 30em;
 	overflow: auto;
@@ -62,32 +62,32 @@
 }
 
 .error {
-	color: red;
+	color: #c50f1f;
 	font-weight: bold;
 }
 
 	.error .stacktrace {
-		color: gray;
+		color: #f2f2f2;
 		font-size: 0.8em;
 	}
 
 	.error .innerexception {
 		margin-left: 2em;
-		color: red;
+		color: #c50f1f;
 	}
 
 .warning {
-	color: #FF8000;
+	color: #c19c00;
 }
 
 .debug {
-	color: #FFF;
+	color: #f2f2f2;
 }
 
 .expand {
-	border: 2px solid #0F0;
+	border: 2px solid #13a10e;
 	background-color: transparent;
-	color: #0F0;
+	color: #13a10e;
 	display: block;
 	font-family: Consolas, 'Courier New', Courier, monospace;
 	margin-bottom: 1em;


### PR DESCRIPTION
Colors taken from updated Windows 10 console: https://blogs.msdn.microsoft.com/commandline/2017/08/02/updating-the-windows-console-colors/